### PR TITLE
Change opencv-headless-python to opencv-python in requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv/
 .env
 backend/.venv/
 backend/.python-version
+.python-version
 
 # models / data
 *.onnx

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+rtsl-env

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,6 +37,7 @@ nvidia-nvjitlink-cu12==12.8.93
 nvidia-nvtx-cu12==12.8.90
 opencv-python==4.12.0.88
 pillow==11.3.0
+opencv-python==4.12.0.88
 pydantic==2.11.9
 pydantic_core==2.33.2
 Pygments==2.19.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,7 +37,6 @@ nvidia-nvjitlink-cu12==12.8.93
 nvidia-nvtx-cu12==12.8.90
 opencv-python==4.12.0.88
 pillow==11.3.0
-opencv-python==4.12.0.88
 pydantic==2.11.9
 pydantic_core==2.33.2
 Pygments==2.19.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -35,7 +35,7 @@ nvidia-cusparselt-cu12==0.7.1
 nvidia-nccl-cu12==2.27.3
 nvidia-nvjitlink-cu12==12.8.93
 nvidia-nvtx-cu12==12.8.90
-opencv-python-headless==4.12.0.88
+opencv-python==4.12.0.88
 pillow==11.3.0
 pydantic==2.11.9
 pydantic_core==2.33.2


### PR DESCRIPTION
The headless version of opencv doesn't have gui functions like imshow() which are good for testing. The rest of the changes are adding pyenv generated stuff to gitignore.